### PR TITLE
Add release editing for specific version branch

### DIFF
--- a/.github/release-drafter-main.yml
+++ b/.github/release-drafter-main.yml
@@ -33,22 +33,22 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 version-resolver:
   major:
     labels:
-      - 'type: breaking'
+      - 'breaking'
   minor:
     labels:
-      - 'type: feature'
-      - 'type: enhancement'
+      - 'feature'
+      - 'enhancement'
   patch:
     labels:
-      - 'type: fix'
-      - 'type: bugfix'
-      - 'type: security'
-      - 'type: maintenance'
-      - 'type: docs'
-      - 'type: documentation'
-      - 'type: dependencies'
-      - 'type: test'
-      - 'type: chore'
+      - 'fix'
+      - 'bugfix'
+      - 'security'
+      - 'maintenance'
+      - 'docs'
+      - 'documentation'
+      - 'dependencies'
+      - 'test'
+      - 'chore'
 exclude-labels:
   - 'skip-changelog'
 autolabeler:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,3 +22,6 @@ jobs:
           BRANCH_NAME=$(echo "$TAG_NAME" | sed 's/\.[0-9]*$/\.x/') # Output e.g. v0.1.x
           git checkout -b release/$BRANCH_NAME
           git push origin release/$BRANCH_NAME
+          gh release edit $TAG_NAME --target release/$BRANCH_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds the ability to edit releases for a specific version branch. It includes a new job in the CI pipeline that checks out a release branch based on the tag name and pushes it to the remote repository. Additionally, it uses the GitHub CLI to edit the release with the specified tag name and target branch.