### PR TITLE
Update links to changes in release configuration file

### DIFF
--- a/.github/release-drafter-main.yml
+++ b/.github/release-drafter-main.yml
@@ -70,4 +70,4 @@ template: |
 
   $CHANGES
 
-  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION/)
+  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION/)

--- a/.github/release-drafter-release.yml
+++ b/.github/release-drafter-release.yml
@@ -31,4 +31,4 @@ template: |
 
   $CHANGES
 
-  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION/)
+  For more details see the [full list of changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION/)


### PR DESCRIPTION
This pull request updates the links in the release configuration file to include the version number with a "v" prefix. This ensures that the links point to the correct comparison between the previous tag and the resolved version.